### PR TITLE
Support retries for aborted taskruns

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -272,6 +272,7 @@ PiplineTask defines a task in a Pipeline, passing inputs from both `Params`` and
 | `params`     | [][`Param`](#param)                                               | REQUIRED    | Declares parameters passed to this task.                                                                                                                                          |
 | `workspaces` | [][`WorkspacePipelineTaskBinding`](#workspacepipelinetaskbinding) | REQUIRED    | Workspaces maps workspaces from the pipeline spec to the workspaces declared in the Task.                                                                                         |
 | `timeout`    | int64                                                             | REQUIRED    | Time after which the TaskRun times out.  Setting the timeout to 0 implies no timeout. There isn't a default max timeout set.                                                      |
+| `retryOn`    | string (Enum: `"notSucceeded"`, `"noResult"`)                  | OPTIONAL    | Controls when retries are attempted for this task (see also the [`retries` field](pipelines.md#using-the-retries-field)). The default is `"notSucceeded"` which retries when the TaskRun's `Succeeded` condition is `False`. Set to `"noResult"` to retry when the TaskRun is in a terminal `Unknown` state and all steps have terminated (i.e., no conclusive success or failure result). |
 
 ### TaskRef
 

--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -2974,7 +2974,19 @@ int
 </td>
 <td>
 <em>(Optional)</em>
-<p>Retries represents how many times this task should be retried in case of task failure: ConditionSucceeded set to False</p>
+<p>Retries represents how many times this task should be retried when a retry is triggered. See also <code>retryOn</code> to control which outcomes trigger a retry.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retryOn</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Controls when retries are attempted for this task. One of <code>notSucceeded</code> (default) or <code>noResult</code>. <code>notSucceeded</code> retries when the TaskRun's <code>Succeeded</code> condition is <code>False</code>. <code>noResult</code> retries when the TaskRun is in a terminal <code>Unknown</code> state and all steps have terminated (no conclusive success or failure result).</p>
 </td>
 </tr>
 <tr>

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -739,6 +739,28 @@ tasks:
       name: build-push
 ```
 
+### Controlling when retries happen with `retryOn`
+
+By default, retries occur when a `TaskRun` explicitly fails (`Succeeded` condition is `False`). You can fine-tune this behavior per `PipelineTask` with the optional `retryOn` field:
+
+- `notSucceeded` (default): retry when the `TaskRun` is marked `False` (failed).
+- `noResult`: retry when the `TaskRun` remains in a terminal `Unknown` state and all steps have terminated, meaning no conclusive success or failure result was produced (for example, infrastructure conditions prevented a clear result).
+
+This allows you to avoid retrying on clear user failures while still retrying on inconclusive outcomes.
+
+Example: retry only when there is no conclusive result
+
+```yaml
+tasks:
+  - name: build-the-image
+    retries: 1
+    retryOn: noResult
+    taskRef:
+      name: build-push
+```
+
+Note: `retryOn` does not change how many retries are attempted (use `retries` for that); it only controls under which status outcomes a retry is triggered.
+
 ### Using the `onError` field
 
 When a `PipelineTask` fails, the rest of the `PipelineTasks` are skipped and the `PipelineRun` is declared a failure. If you would like to

--- a/pkg/apis/pipeline/v1/pipeline_defaults.go
+++ b/pkg/apis/pipeline/v1/pipeline_defaults.go
@@ -60,4 +60,8 @@ func (pt *PipelineTask) SetDefaults(ctx context.Context) {
 	if pt.TaskSpec != nil {
 		pt.TaskSpec.SetDefaults(ctx)
 	}
+	// Default retryOn to "notSucceeded" if unset
+	if pt.RetryOn == "" {
+		pt.RetryOn = "notSucceeded"
+	}
 }

--- a/pkg/apis/pipeline/v1/pipeline_defaults_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_defaults_test.go
@@ -173,6 +173,7 @@ func TestPipelineTask_SetDefaults(t *testing.T) {
 				Name: "foo-task",
 				Kind: v1.NamespacedTaskKind,
 			},
+			RetryOn: "notSucceeded",
 		},
 	}, {
 		desc: "pipeline task with taskSpec - default param type must be " + string(v1.ParamTypeString),
@@ -196,6 +197,7 @@ func TestPipelineTask_SetDefaults(t *testing.T) {
 					}},
 				},
 			},
+			RetryOn: "notSucceeded",
 		},
 	}, {
 		desc: "pipeline task with taskRef - with default resolver",
@@ -210,6 +212,7 @@ func TestPipelineTask_SetDefaults(t *testing.T) {
 					Resolver: "git",
 				},
 			},
+			RetryOn: "notSucceeded",
 		},
 		defaults: map[string]string{
 			"default-resolver-type": "git",
@@ -231,6 +234,7 @@ func TestPipelineTask_SetDefaults(t *testing.T) {
 					Resolver: "custom resolver",
 				},
 			},
+			RetryOn: "notSucceeded",
 		},
 		defaults: map[string]string{
 			"default-resolver-type": "git",

--- a/pkg/apis/pipeline/v1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1/pipeline_types.go
@@ -217,6 +217,14 @@ type PipelineTask struct {
 	// +optional
 	Retries int `json:"retries,omitempty"`
 
+	// RetryOn controls when a failed attempt should be retried.
+	// Supported values:
+	// - "notSucceeded" (default): retry when completion status != Succeeded
+	// - "noResult": retry when completion is neither Failed nor Succeeded
+	// +kubebuilder:validation:Enum=notSucceeded;noResult
+	// +optional
+	RetryOn string `json:"retryOn,omitempty"`
+
 	// RunAfter is the list of PipelineTask names that should be executed before
 	// this Task executes. (Used to force a specific ordering in graph execution.)
 	// +optional

--- a/pkg/apis/pipeline/v1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_types_test.go
@@ -156,6 +156,70 @@ func TestPipelineTask_OnError(t *testing.T) {
 	}
 }
 
+func TestPipelineTask_RetryOn_Validation(t *testing.T) {
+	tests := []struct {
+		name          string
+		p             PipelineTask
+		expectedError *apis.FieldError
+	}{
+		{
+			name: "valid retryOn notSucceeded",
+			p: PipelineTask{
+				Name:    "foo",
+				RetryOn: "notSucceeded",
+				TaskRef: &TaskRef{Name: "foo"},
+			},
+		},
+		{
+			name: "valid retryOn noResult",
+			p: PipelineTask{
+				Name:    "foo",
+				RetryOn: "noResult",
+				TaskRef: &TaskRef{Name: "foo"},
+			},
+		},
+		{
+			name: "invalid retryOn value",
+			p: PipelineTask{
+				Name:    "foo",
+				RetryOn: "invalid-val",
+				TaskRef: &TaskRef{Name: "foo"},
+			},
+			expectedError: apis.ErrInvalidValue("invalid-val", "retryOn", "PipelineTask retryOn must be either \"notSucceeded\" or \"noResult\""),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			err := tt.p.Validate(ctx)
+			if tt.expectedError == nil {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
+					t.Errorf("PipelineTask.Validate() errors diff %s", diff.PrintWantGot(d))
+				}
+			}
+		})
+	}
+}
+
+func TestPipelineTask_RetryOn_Default(t *testing.T) {
+	pt := &PipelineTask{
+		Name:    "foo",
+		TaskRef: &TaskRef{Name: "foo"},
+	}
+	ctx := t.Context()
+	pt.SetDefaults(ctx)
+	if pt.RetryOn != "notSucceeded" {
+		t.Fatalf("default retryOn = %q, want notSucceeded", pt.RetryOn)
+	}
+}
+
 func TestPipelineTask_ValidateRefOrSpec(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -192,6 +192,16 @@ func (pt PipelineTask) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 	errs = errs.Also(pt.ValidateOnError(ctx))
 
+	// Validate RetryOn values when specified as a literal (not a param ref)
+	if pt.RetryOn != "" && !isParamRefs(pt.RetryOn) {
+		switch pt.RetryOn {
+		case "notSucceeded", "noResult":
+			// ok
+		default:
+			errs = errs.Also(apis.ErrInvalidValue(pt.RetryOn, "retryOn", "PipelineTask retryOn must be either \"notSucceeded\" or \"noResult\""))
+		}
+	}
+
 	// Pipeline task having taskRef/taskSpec with APIVersion is classified as custom task
 	switch {
 	case pt.TaskRef != nil && !taskKinds[pt.TaskRef.Kind]:

--- a/pkg/apis/pipeline/v1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types.go
@@ -427,6 +427,9 @@ const (
 // PipelineTaskOnErrorAnnotation is used to pass the failure strategy to TaskRun pods from PipelineTask OnError field
 const PipelineTaskOnErrorAnnotation = "pipeline.tekton.dev/pipeline-task-on-error"
 
+// PipelineTaskRetryOnAnnotation is used to pass the retry strategy to TaskRun from PipelineTask retryOn field
+const PipelineTaskRetryOnAnnotation = "pipeline.tekton.dev/pipeline-task-retry-on"
+
 func (t PipelineRunReason) String() string {
 	return string(t)
 }

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1069,6 +1069,11 @@ func (c *Reconciler) createTaskRun(ctx context.Context, taskRunName string, para
 		tr.Annotations[v1.PipelineTaskOnErrorAnnotation] = string(v1.PipelineTaskContinue)
 	}
 
+	// Propagate retryOn behavior from PipelineTask to TaskRun via annotation
+	if rpt.PipelineTask.RetryOn != "" {
+		tr.Annotations[v1.PipelineTaskRetryOnAnnotation] = rpt.PipelineTask.RetryOn
+	}
+
 	if rpt.PipelineTask.Timeout != nil {
 		tr.Spec.Timeout = rpt.PipelineTask.Timeout
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -18386,3 +18386,85 @@ spec:
 		})
 	}
 }
+
+// TestCreateTaskRun_PropagatesRetryOn verifies that PipelineTask.retryOn is propagated
+// as an annotation on the created TaskRun.
+func TestCreateTaskRun_PropagatesRetryOn(t *testing.T) {
+	prName := "test-pr"
+	namespace := "default"
+	pr := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: prName, Namespace: namespace},
+		Spec: v1.PipelineRunSpec{
+			PipelineSpec: &v1.PipelineSpec{
+				Tasks: []v1.PipelineTask{{
+					Name:    "hello",
+					TaskRef: &v1.TaskRef{Name: "hello-task"},
+				}},
+			},
+		},
+	}
+
+	// Feature flags minimal config
+	featureFlagsConfig := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: system.Namespace(), Name: config.GetFeatureFlagsConfigName()},
+		Data:       map[string]string{"enable-wait-exponential-backoff": "false"},
+	}
+
+	// Seed a simple Task so resolution succeeds
+	task := &v1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "hello-task", Namespace: namespace},
+		Spec:       v1.TaskSpec{Steps: []v1.Step{{Name: "s", Image: "busybox", Script: "echo hi"}}},
+	}
+
+	d := test.Data{
+		PipelineRuns: []*v1.PipelineRun{pr},
+		Tasks:        []*v1.Task{task},
+		ConfigMaps:   []*corev1.ConfigMap{featureFlagsConfig},
+	}
+	testAssets, cancel := getPipelineRunController(t, d)
+	defer cancel()
+	r := &Reconciler{
+		KubeClientSet:     testAssets.Clients.Kube,
+		PipelineClientSet: testAssets.Clients.Pipeline,
+		Clock:             clock.NewFakePassiveClock(time.Now()),
+		tracerProvider:    tracing.New("pipelinerun", logtesting.TestLogger(t)),
+	}
+
+	// Capture the created TaskRun to assert annotations
+	var createdTR *v1.TaskRun
+	testAssets.Clients.Pipeline.PrependReactor("create", "taskruns", func(action ktesting.Action) (bool, runtime.Object, error) {
+		createAction := action.(ktesting.CreateAction)
+		tr := createAction.GetObject().(*v1.TaskRun)
+		createdTR = tr
+		return true, tr, nil
+	})
+
+	// Build a ResolvedPipelineTask with retryOn set
+	rpt := &resources.ResolvedPipelineTask{
+		PipelineTask: &v1.PipelineTask{
+			Name:    "hello",
+			RetryOn: "noResult",
+			TaskRef: &v1.TaskRef{Name: "hello-task"},
+		},
+		ResolvedTask: &taskresources.ResolvedTask{
+			TaskName: "hello-task",
+			TaskSpec: &v1.TaskSpec{Steps: []v1.Step{{Name: "s", Image: "busybox", Script: "echo hi"}}},
+		},
+	}
+
+	facts := &resources.PipelineRunFacts{}
+	trName := "test-pr-hello"
+	ctx := testAssets.Ctx
+
+	result, err := r.createTaskRun(ctx, trName, nil, rpt, pr, facts)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if result == nil || createdTR == nil {
+		t.Fatalf("expected TaskRun to be created")
+	}
+	got := createdTR.Annotations[v1.PipelineTaskRetryOnAnnotation]
+	if got != "noResult" {
+		t.Fatalf("expected annotation %s=noResult, got %q", v1.PipelineTaskRetryOnAnnotation, got)
+	}
+}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -364,9 +364,29 @@ func (c *Reconciler) finishReconcileUpdateEmitEvents(ctx context.Context, tr *v1
 	logger := logging.FromContext(ctx)
 
 	afterCondition := tr.Status.GetCondition(apis.ConditionSucceeded)
-	if afterCondition.IsFalse() && !tr.IsCancelled() && tr.IsRetriable() {
-		retryTaskRun(tr, afterCondition.Message)
-		afterCondition = tr.Status.GetCondition(apis.ConditionSucceeded)
+	// Determine retry behavior based on annotation propagated from PipelineTask
+	retryOn := tr.Annotations[v1.PipelineTaskRetryOnAnnotation]
+	if retryOn == "" {
+		retryOn = "notSucceeded"
+	}
+	if !tr.IsCancelled() && tr.IsRetriable() {
+		switch retryOn {
+		case "noResult":
+			// Retry when the TaskRun reached a terminal state without a clear Succeeded/Failed outcome.
+			// Guard against retrying while still running by ensuring all steps are terminated.
+			if afterCondition.IsUnknown() && isTerminalNoResult(tr) {
+				retryTaskRun(tr, afterCondition.Message)
+				afterCondition = tr.Status.GetCondition(apis.ConditionSucceeded)
+			}
+		case "notSucceeded":
+			fallthrough
+		default:
+			// Default behavior: retry on explicit failure only
+			if afterCondition.IsFalse() {
+				retryTaskRun(tr, afterCondition.Message)
+				afterCondition = tr.Status.GetCondition(apis.ConditionSucceeded)
+			}
+		}
 	}
 	// Send k8s events and cloud events (when configured)
 	events.Emit(ctx, beforeCondition, afterCondition, tr)
@@ -389,6 +409,21 @@ func (c *Reconciler) finishReconcileUpdateEmitEvents(ctx context.Context, tr *v1
 		return controller.NewPermanentError(joinedErr)
 	}
 	return joinedErr
+}
+
+// isTerminalNoResult returns true if all step containers have terminated but the TaskRun
+// ConditionSucceeded remains Unknown, indicating no definitive result.
+func isTerminalNoResult(tr *v1.TaskRun) bool {
+	// If there are no recorded step states, we cannot assert terminality.
+	if len(tr.Status.Steps) == 0 {
+		return false
+	}
+	for _, s := range tr.Status.Steps {
+		if s.Terminated == nil {
+			return false
+		}
+	}
+	return true
 }
 
 // `prepare` fetches resources the taskrun depends on, runs validation and conversion

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -165,13 +165,17 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 				logger.Infof("Using Kubernetes Native Sidecars \n")
 			}
 		}
+		var stopErr error
 		if useTektonSidecar {
 			if err := c.stopSidecars(ctx, tr); err != nil {
-				return err
+				// Propagate the error to finishReconcileUpdateEmitEvents so that we still
+				// evaluate retry logic (e.g., retryOn=noResult) and emit events before
+				// returning a permanent error.
+				stopErr = err
 			}
 		}
 
-		return c.finishReconcileUpdateEmitEvents(ctx, tr, before, nil)
+		return c.finishReconcileUpdateEmitEvents(ctx, tr, before, stopErr)
 	}
 
 	// If the TaskRun is cancelled, kill resources and update status
@@ -405,6 +409,9 @@ func (c *Reconciler) finishReconcileUpdateEmitEvents(ctx context.Context, tr *v1
 		}
 	}
 	joinedErr := errors.Join(errs...)
+	// If stopSidecars (or another earlier step) yielded a permanent error, return it after
+	// we handled retries/events/annotations above. This preserves the prior behavior of
+	// surfacing a permanent error while allowing retryOn to be evaluated.
 	if controller.IsPermanentError(previousError) {
 		return controller.NewPermanentError(joinedErr)
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -592,6 +592,56 @@ spec:
 		}
 	})
 
+	// When the pod disappears (deleted/evicted) we still evaluate retryOn=noResult and trigger a retry
+	t.Run("RetryOn noResult: pod deleted counts as noResult and triggers retry", func(t *testing.T) {
+		tr := &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tr-noresult-pod-deleted",
+				Namespace: "foo",
+				Annotations: map[string]string{
+					v1.PipelineTaskRetryOnAnnotation: "noResult",
+				},
+			},
+			Spec: v1.TaskRunSpec{Retries: 1, TaskRef: &v1.TaskRef{Name: "test-task"}},
+			Status: v1.TaskRunStatus{
+				TaskRunStatusFields: v1.TaskRunStatusFields{
+					PodName: "pod-gone",
+					Steps: []v1.StepState{
+						{ContainerState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0, Reason: "Completed"}}, Name: "step1", Container: "step-step1"},
+						{ContainerState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0, Reason: "Completed"}}, Name: "step2", Container: "step-step2"},
+					},
+				},
+			},
+		}
+		tr.Status.Conditions = append(tr.Status.Conditions, apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionUnknown,
+			Reason:  v1.TaskRunReasonRunning.String(),
+			Message: "pod disappeared",
+		})
+
+		data := test.Data{TaskRuns: []*v1.TaskRun{tr}, Tasks: []*v1.Task{simpleTask}}
+		testAssets, cancel := getTaskRunController(t, data)
+		defer cancel()
+		c := testAssets.Controller
+		createServiceAccount(t, testAssets, "default", tr.Namespace)
+		// No pod seeded in the lister; since tr.Status.PodName is set, Get will be NotFound.
+		if err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(tr)); err != nil {
+			// Allow a requeue error, but not a hard failure
+			if ok, _ := controller.IsRequeueKey(err); !ok {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		}
+		got, err := testAssets.Clients.Pipeline.TektonV1().TaskRuns(tr.Namespace).Get(testAssets.Ctx, tr.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("get tr: %v", err)
+		}
+		cond := got.Status.GetCondition(apis.ConditionSucceeded)
+		if cond == nil || cond.Reason != v1.TaskRunReasonToBeRetried.String() || cond.Status != corev1.ConditionUnknown {
+			t.Fatalf("expected ToBeRetried Unknown after pod deletion, got %v", cond)
+		}
+	})
+
 	t.Run("RetryOn noResult: do not retry on explicit failure", func(t *testing.T) {
 		tr := &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -542,6 +542,90 @@ spec:
 			}
 		})
 	}
+
+		// Additional tests for retryOn noResult behavior
+		t.Run("RetryOn noResult: retry when terminal Unknown and steps terminated", func(t *testing.T) {
+				tr := parse.MustParseV1TaskRun(t, `
+metadata:
+	name: tr-noresult-retry
+	namespace: foo
+	annotations:
+		pipeline.tekton.dev/pipeline-task-retry-on: noResult
+spec:
+	retries: 1
+status:
+	steps:
+	- name: step1
+		container: step-step1
+		terminated:
+			exitCode: 0
+			reason: Completed
+	- name: step2
+		container: step-step2
+		terminated:
+			exitCode: 0
+			reason: Completed
+	conditions:
+	- type: Succeeded
+		status: Unknown
+		reason: Running
+		message: "pending status"
+`)
+				data := test.Data{TaskRuns: []*v1.TaskRun{tr}}
+				testAssets, cancel := getTaskRunController(t, data)
+				defer cancel()
+				c := testAssets.Controller
+				createServiceAccount(t, testAssets, "default", tr.Namespace)
+				if err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(tr)); err != nil {
+						if ok, _ := controller.IsRequeueKey(err); !ok {
+								t.Fatalf("unexpected error: %v", err)
+						}
+				}
+				got, err := testAssets.Clients.Pipeline.TektonV1().TaskRuns(tr.Namespace).Get(testAssets.Ctx, tr.Name, metav1.GetOptions{})
+				if err != nil {
+						t.Fatalf("get tr: %v", err)
+				}
+				cond := got.Status.GetCondition(apis.ConditionSucceeded)
+				if cond == nil || cond.Reason != v1.TaskRunReasonToBeRetried.String() || cond.Status != corev1.ConditionUnknown {
+						t.Fatalf("expected ToBeRetried Unknown, got %v", cond)
+				}
+		})
+
+		t.Run("RetryOn noResult: do not retry on explicit failure", func(t *testing.T) {
+				tr := parse.MustParseV1TaskRun(t, `
+metadata:
+	name: tr-noresult-no-retry-on-failed
+	namespace: foo
+	annotations:
+		pipeline.tekton.dev/pipeline-task-retry-on: noResult
+spec:
+	retries: 1
+status:
+	conditions:
+	- type: Succeeded
+		status: "False"
+		reason: Failed
+		message: "explicit failure"
+`)
+				data := test.Data{TaskRuns: []*v1.TaskRun{tr}}
+				testAssets, cancel := getTaskRunController(t, data)
+				defer cancel()
+				c := testAssets.Controller
+				createServiceAccount(t, testAssets, "default", tr.Namespace)
+				if err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(tr)); err != nil {
+						if ok, _ := controller.IsRequeueKey(err); !ok {
+								t.Fatalf("unexpected error: %v", err)
+						}
+				}
+				got, err := testAssets.Clients.Pipeline.TektonV1().TaskRuns(tr.Namespace).Get(testAssets.Ctx, tr.Name, metav1.GetOptions{})
+				if err != nil {
+						t.Fatalf("get tr: %v", err)
+				}
+				cond := got.Status.GetCondition(apis.ConditionSucceeded)
+				if cond == nil || cond.Reason == v1.TaskRunReasonToBeRetried.String() {
+						t.Fatalf("expected no retry on Failed, got %v", cond)
+				}
+		})
 }
 
 // TestReconcile_CloudEvents runs reconcile with a cloud event sink configured

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -543,89 +543,94 @@ spec:
 		})
 	}
 
-		// Additional tests for retryOn noResult behavior
-		t.Run("RetryOn noResult: retry when terminal Unknown and steps terminated", func(t *testing.T) {
-				tr := parse.MustParseV1TaskRun(t, `
-metadata:
-	name: tr-noresult-retry
-	namespace: foo
-	annotations:
-		pipeline.tekton.dev/pipeline-task-retry-on: noResult
-spec:
-	retries: 1
-status:
-	steps:
-	- name: step1
-		container: step-step1
-		terminated:
-			exitCode: 0
-			reason: Completed
-	- name: step2
-		container: step-step2
-		terminated:
-			exitCode: 0
-			reason: Completed
-	conditions:
-	- type: Succeeded
-		status: Unknown
-		reason: Running
-		message: "pending status"
-`)
-				data := test.Data{TaskRuns: []*v1.TaskRun{tr}}
-				testAssets, cancel := getTaskRunController(t, data)
-				defer cancel()
-				c := testAssets.Controller
-				createServiceAccount(t, testAssets, "default", tr.Namespace)
-				if err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(tr)); err != nil {
-						if ok, _ := controller.IsRequeueKey(err); !ok {
-								t.Fatalf("unexpected error: %v", err)
-						}
-				}
-				got, err := testAssets.Clients.Pipeline.TektonV1().TaskRuns(tr.Namespace).Get(testAssets.Ctx, tr.Name, metav1.GetOptions{})
-				if err != nil {
-						t.Fatalf("get tr: %v", err)
-				}
-				cond := got.Status.GetCondition(apis.ConditionSucceeded)
-				if cond == nil || cond.Reason != v1.TaskRunReasonToBeRetried.String() || cond.Status != corev1.ConditionUnknown {
-						t.Fatalf("expected ToBeRetried Unknown, got %v", cond)
-				}
+	// Additional tests for retryOn noResult behavior
+	t.Run("RetryOn noResult: retry when terminal Unknown and steps terminated", func(t *testing.T) {
+		tr := &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tr-noresult-retry",
+				Namespace: "foo",
+				Annotations: map[string]string{
+					v1.PipelineTaskRetryOnAnnotation: "noResult",
+				},
+			},
+			Spec: v1.TaskRunSpec{
+				Retries: 1,
+				TaskRef: &v1.TaskRef{Name: "test-task"},
+			},
+			Status: v1.TaskRunStatus{
+				TaskRunStatusFields: v1.TaskRunStatusFields{
+					Steps: []v1.StepState{
+						{ContainerState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0, Reason: "Completed"}}, Name: "step1", Container: "step-step1"},
+						{ContainerState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0, Reason: "Completed"}}, Name: "step2", Container: "step-step2"},
+					},
+				},
+			},
+		}
+		tr.Status.Conditions = append(tr.Status.Conditions, apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionUnknown,
+			Reason:  v1.TaskRunReasonRunning.String(),
+			Message: "pending status",
 		})
+		data := test.Data{TaskRuns: []*v1.TaskRun{tr}, Tasks: []*v1.Task{simpleTask}}
+		testAssets, cancel := getTaskRunController(t, data)
+		defer cancel()
+		c := testAssets.Controller
+		createServiceAccount(t, testAssets, "default", tr.Namespace)
+		if err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(tr)); err != nil {
+			if ok, _ := controller.IsRequeueKey(err); !ok {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		}
+		got, err := testAssets.Clients.Pipeline.TektonV1().TaskRuns(tr.Namespace).Get(testAssets.Ctx, tr.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("get tr: %v", err)
+		}
+		cond := got.Status.GetCondition(apis.ConditionSucceeded)
+		if cond == nil || cond.Reason != v1.TaskRunReasonToBeRetried.String() || cond.Status != corev1.ConditionUnknown {
+			t.Fatalf("expected ToBeRetried Unknown, got %v", cond)
+		}
+	})
 
-		t.Run("RetryOn noResult: do not retry on explicit failure", func(t *testing.T) {
-				tr := parse.MustParseV1TaskRun(t, `
-metadata:
-	name: tr-noresult-no-retry-on-failed
-	namespace: foo
-	annotations:
-		pipeline.tekton.dev/pipeline-task-retry-on: noResult
-spec:
-	retries: 1
-status:
-	conditions:
-	- type: Succeeded
-		status: "False"
-		reason: Failed
-		message: "explicit failure"
-`)
-				data := test.Data{TaskRuns: []*v1.TaskRun{tr}}
-				testAssets, cancel := getTaskRunController(t, data)
-				defer cancel()
-				c := testAssets.Controller
-				createServiceAccount(t, testAssets, "default", tr.Namespace)
-				if err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(tr)); err != nil {
-						if ok, _ := controller.IsRequeueKey(err); !ok {
-								t.Fatalf("unexpected error: %v", err)
-						}
-				}
-				got, err := testAssets.Clients.Pipeline.TektonV1().TaskRuns(tr.Namespace).Get(testAssets.Ctx, tr.Name, metav1.GetOptions{})
-				if err != nil {
-						t.Fatalf("get tr: %v", err)
-				}
-				cond := got.Status.GetCondition(apis.ConditionSucceeded)
-				if cond == nil || cond.Reason == v1.TaskRunReasonToBeRetried.String() {
-						t.Fatalf("expected no retry on Failed, got %v", cond)
-				}
+	t.Run("RetryOn noResult: do not retry on explicit failure", func(t *testing.T) {
+		tr := &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tr-noresult-no-retry-on-failed",
+				Namespace: "foo",
+				Annotations: map[string]string{
+					v1.PipelineTaskRetryOnAnnotation: "noResult",
+				},
+			},
+			Spec: v1.TaskRunSpec{
+				Retries: 1,
+				TaskRef: &v1.TaskRef{Name: "test-task"},
+			},
+		}
+		tr.Status.Conditions = append(tr.Status.Conditions, apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionFalse,
+			Reason:  v1.TaskRunReasonFailed.String(),
+			Message: "explicit failure",
 		})
+		data := test.Data{TaskRuns: []*v1.TaskRun{tr}, Tasks: []*v1.Task{simpleTask}}
+		testAssets, cancel := getTaskRunController(t, data)
+		defer cancel()
+		c := testAssets.Controller
+		createServiceAccount(t, testAssets, "default", tr.Namespace)
+		if err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(tr)); err != nil {
+			if ok, _ := controller.IsRequeueKey(err); !ok {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		}
+		got, err := testAssets.Clients.Pipeline.TektonV1().TaskRuns(tr.Namespace).Get(testAssets.Ctx, tr.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("get tr: %v", err)
+		}
+		cond := got.Status.GetCondition(apis.ConditionSucceeded)
+		if cond == nil || cond.Reason == v1.TaskRunReasonToBeRetried.String() {
+			t.Fatalf("expected no retry on Failed, got %v", cond)
+		}
+	})
 }
 
 // TestReconcile_CloudEvents runs reconcile with a cloud event sink configured
@@ -1609,61 +1614,75 @@ status:
     startTime: "2021-12-31T00:00:00Z"
     completionTime: "2022-01-01T00:00:00Z"
     `)
-		toFailOnPodFailureTaskRun = parse.MustParseV1TaskRun(t, `
-metadata:
-  name: test-taskrun-run-retry-pod-failure
-  namespace: foo
-spec:
-  retries: 1
-  taskRef:
-    name: test-task
-status:
-  startTime: "2021-12-31T23:59:59Z"
-  podName: test-taskrun-run-retry-pod-failure-pod
-  steps:
-  - container: step-unamed-0
-    name: unamed-0
-    waiting:
-      reason: "ImagePullBackOff"
-`)
-		failedOnPodFailureTaskRun = parse.MustParseV1TaskRun(t, `
-metadata:
-  name: test-taskrun-run-retry-pod-failure
-  namespace: foo
-spec:
-  retries: 1
-  taskRef:
-    name: test-task
-status:
-  conditions:
-  - reason: ToBeRetried
-    status: Unknown
-    type: Succeeded
-    message: "the step \"unamed-0\" in TaskRun \"test-taskrun-run-retry-pod-failure\" failed to pull the image \"\". The pod errored with the message: \".\""
-  steps:
-  - container: step-unamed-0
-    name: unamed-0
-    terminated:
-      exitCode: 1
-      finishedAt: "2022-01-01T00:00:00Z"
-      reason: "TaskRunImagePullFailed"
-  retriesStatus:
-  - conditions:
-    - reason: "TaskRunImagePullFailed"
-      status: "False"
-      type: Succeeded
-      message: "the step \"unamed-0\" in TaskRun \"test-taskrun-run-retry-pod-failure\" failed to pull the image \"\". The pod errored with the message: \".\""
-    startTime: "2021-12-31T23:59:59Z"
-    completionTime: "2022-01-01T00:00:00Z"
-    podName: test-taskrun-run-retry-pod-failure-pod
-    steps:
-    - container: step-unamed-0
-      name: unamed-0
-      terminated:
-        exitCode: 1
-        finishedAt: "2022-01-01T00:00:00Z"
-        reason: "TaskRunImagePullFailed"
-`)
+		toFailOnPodFailureTaskRun = &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-taskrun-run-retry-pod-failure",
+				Namespace: "foo",
+			},
+			Spec: v1.TaskRunSpec{
+				Retries: 1,
+				TaskRef: &v1.TaskRef{Name: "test-task"},
+			},
+			Status: v1.TaskRunStatus{
+				TaskRunStatusFields: v1.TaskRunStatusFields{
+					StartTime: &metav1.Time{Time: time.Date(2021, 12, 31, 23, 59, 59, 0, time.UTC)},
+					PodName:   "test-taskrun-run-retry-pod-failure-pod",
+					Steps: []v1.StepState{{
+						Name:           "unamed-0",
+						Container:      "step-unamed-0",
+						ContainerState: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"}},
+					}},
+				},
+			},
+		}
+
+		failedOnPodFailureTaskRun = &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-taskrun-run-retry-pod-failure",
+				Namespace: "foo",
+			},
+			Spec: v1.TaskRunSpec{
+				Retries: 1,
+				TaskRef: &v1.TaskRef{Name: "test-task"},
+			},
+			Status: v1.TaskRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{apis.Condition{
+						Type:    apis.ConditionSucceeded,
+						Status:  corev1.ConditionUnknown,
+						Reason:  v1.TaskRunReasonToBeRetried.String(),
+						Message: "the step \"unamed-0\" in TaskRun \"test-taskrun-run-retry-pod-failure\" failed to pull the image \"\". The pod errored with the message: \".\"",
+					}},
+				},
+				TaskRunStatusFields: v1.TaskRunStatusFields{
+					Steps: []v1.StepState{{
+						Name:           "unamed-0",
+						Container:      "step-unamed-0",
+						ContainerState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "TaskRunImagePullFailed", FinishedAt: metav1.NewTime(time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC))}},
+					}},
+					RetriesStatus: []v1.TaskRunStatus{{
+						Status: duckv1.Status{
+							Conditions: duckv1.Conditions{apis.Condition{
+								Type:    apis.ConditionSucceeded,
+								Status:  corev1.ConditionFalse,
+								Reason:  "TaskRunImagePullFailed",
+								Message: "the step \"unamed-0\" in TaskRun \"test-taskrun-run-retry-pod-failure\" failed to pull the image \"\". The pod errored with the message: \".\"",
+							}},
+						},
+						TaskRunStatusFields: v1.TaskRunStatusFields{
+							StartTime:      &metav1.Time{Time: time.Date(2021, 12, 31, 23, 59, 59, 0, time.UTC)},
+							CompletionTime: &metav1.Time{Time: time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)},
+							PodName:        "test-taskrun-run-retry-pod-failure-pod",
+							Steps: []v1.StepState{{
+								Name:           "unamed-0",
+								Container:      "step-unamed-0",
+								ContainerState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "TaskRunImagePullFailed", FinishedAt: metav1.NewTime(time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC))}},
+							}},
+						},
+					}},
+				},
+			},
+		}
 		failedPod = &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-taskrun-run-retry-pod-failure-pod"},
 			Status: corev1.PodStatus{Conditions: []corev1.PodCondition{{


### PR DESCRIPTION
We rarely want pipelines to retry on task failure because, while sometimes providing a relief for flaky tests or remote dependencies, it frequently just adds build time by repeating the same build failures.

We do however run our CI on GKE spot nodes and we tend to overcommit, meaning that preemption is quite frequent. It would be really helpful to be able to retry on a taskrun that has ended (pod terminated) without neither Successful or Failed result.